### PR TITLE
docs(Readme): aponlexy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Motorcycle TSLint Confiuration
+# Motorcycle TSLint Configuration
 
 TSLint Configuration for Motorcycle.js
 


### PR DESCRIPTION
- Missing 'g' in the headline